### PR TITLE
Fix media galley carousel spin, in RTL mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -345,6 +345,9 @@
 .jcarousel li {
     float: left;
 }
+.dir-rtl .jcarousel li {
+    float: right;
+}
 
 .jcarousel li img {
     max-width: 250px;

--- a/styles.css
+++ b/styles.css
@@ -389,7 +389,7 @@
 }
 
 .dir-rtl .jcarousel-control-next {
-    direction: rtl;
+    direction: ltr;
 }
 
 /** Carousel Pagination **/

--- a/styles.css
+++ b/styles.css
@@ -384,6 +384,13 @@
     right: 15px;
 }
 
+.dir-rtl .jcarousel-control-prev {
+    direction: ltr;
+}
+
+.dir-rtl .jcarousel-control-next {
+    direction: rtl;
+}
 
 /** Carousel Pagination **/
 


### PR DESCRIPTION
Clicking the "right" and "left" arrows on the carousel does not move/change the gallery images.
The suggested fix solves this.
(btw, the arrows should be flipped also, I will send another fix when it is done)