### PR TITLE
Added default captions for accessibility.

### DIFF
--- a/classes/gallery.php
+++ b/classes/gallery.php
@@ -245,6 +245,16 @@ class gallery extends base {
                     'files' => $files,
                     'gallery' => $this,
                 );
+
+                // Replacing empty caption with image filename/video url for
+                // all items in gallery on mouseover for better user experience.
+                if (empty($record->caption)) {
+                    if (!empty($filelist[$record->id])) {
+                        $record->caption =  $filelist[$record->id]['item']->get_filename();
+                    } else if (!empty($record->externalurl)) {
+                        $record->caption = $record->externalurl;
+                    }
+                }
                 $items[$record->id] = new item($record, $options);
             }
         }


### PR DESCRIPTION
This patch uses a file's name or video URL has the default caption for accessibility reasons.

We noticed that this was the behavior when bulk uploading files in a zip, so we wanted to make it apply to everything.

If an teacher wants to change the caption displayed, they can and should change it to something more meaningful.
