### PR TITLE
Fixed the action menu alignment and long filename display issue.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -46,15 +46,25 @@
 .path-mod-mediagallery .item .title {
     margin-left: 5px;
     float: left;
-    overflow: hidden;
-    max-width: 170px;
+    max-width: 100px;
     word-break: break-word;
 }
 
 .path-mod-mediagallery .gallery_list_item .title h6,
 .path-mod-mediagallery .item .title h6 {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100px;
     margin-top: 0px;
     margin-bottom: 0px;
+}
+
+.path-mod-mediagallery .gallery_list_item .title h6:hover,
+.path-mod-mediagallery .item .title h6:hover {
+    white-space: initial;
+    overflow: visible;
+    word-wrap: break-word;
 }
 
 .path-mod-mediagallery .gallery_list_item .controls,


### PR DESCRIPTION
With editing turned on, if there is an item with a long caption the display can appear a bit wonky. For example:

![before](https://cloud.githubusercontent.com/assets/349765/13543470/61164fd6-e220-11e5-9c80-dbc2234bc09e.png)

But with this patch, the long caption is truncated:

![after](https://cloud.githubusercontent.com/assets/349765/13543479/6f4ad590-e220-11e5-98f7-5b9572e77820.png)

If you then hover over the caption, you can view the full text:

![after-hover](https://cloud.githubusercontent.com/assets/349765/13543486/7b6d127a-e220-11e5-9bcd-df34abe910c6.png)
