### PR TITLE
Allowing super users to access the gallery edit menu option.

### DIFF
--- a/classes/gallery.php
+++ b/classes/gallery.php
@@ -414,7 +414,7 @@ class gallery extends base {
             $userid = $USER->id;
         }
 
-        if ($userid == $this->record->userid) {
+        if ($userid == $this->record->userid || has_capability('mod/mediagallery:manage', $this->get_context(), $userid)) {
             return true;
         }
 

--- a/classes/item.php
+++ b/classes/item.php
@@ -869,7 +869,7 @@ class item extends base {
             $userid = $USER->id;
         }
 
-        if ($userid == $this->record->userid) {
+        if ($userid == $this->record->userid || has_capability('mod/mediagallery:manage', $this->get_context(), $userid)) {
             return true;
         }
 


### PR DESCRIPTION
In our testing a Manager, or any other user with the capability 'mod/mediagallery:manage' cannot manage another user's media gallery. This was frustrating for our support staff, so hence this patch.
